### PR TITLE
Fix ansible setup errors & add tmpfiles config for opflex dirs

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -101,7 +101,7 @@
   become_user: "{{ neutron_system_user_name }}"
   delegate_to: "{{ groups[neutron_services['neutron-server']['group']][0] }}"
   when:
-    - "ansible_local['openstack_ansible']['neutron']['need_db_contract'] | bool"
+    - "ansible_local['openstack_ansible']['neutron']['need_db_contract'] | default(false) | bool"
     - "_neutron_is_first_play_host"
   listen:
     - "Restart neutron services"

--- a/tasks/elx_netbilling.yml
+++ b/tasks/elx_netbilling.yml
@@ -104,6 +104,16 @@
   tags:
     - elx-netbilling
 
+- name: Wait for OVS bridges to exist before activating sFlow
+  command: "ovs-vsctl br-exists {{ item }}"
+  loop: "{{ sflow_bridges }}"
+  retries: 30
+  delay: 10
+  register: _bridge_exists
+  until: _bridge_exists.rc == 0
+  tags:
+    - elx-netbilling
+
 - name: Activate sFlow on all Open VSwitch bridges
   shell: 'SFLOWUUID=$(ovs-vsctl -- --id=@sflow create sflow agent={{ inventory_hostname }} target="127.0.0.123\:6343" header=128 sampling=512 polling=30 -- set bridge {{ item }} sflow=@sflow)'
   loop: "{{ sflow_bridges }}"

--- a/tasks/opflex.yml
+++ b/tasks/opflex.yml
@@ -114,6 +114,33 @@
   tags:
     - opflex-config
 
+- name: Create opflex tmpfiles.d config
+  lineinfile:
+    dest: "/etc/tmpfiles.d/opflex-{{ item.name }}.conf"
+    line: "d {{ item.path }} {{ item.mode }} {{ item.user }} {{ item.group }}"
+    create: true
+  with_items:
+    - name: aid
+      path: /var/run/aid
+      mode: "2755"
+      user: neutron
+      group: neutron
+    - name: aid-events
+      path: /var/run/aid/events
+      mode: "2755"
+      user: neutron
+      group: neutron
+    - name: aim-aid
+      path: /var/run/aim-aid
+      mode: "2755"
+      user: neutron
+      group: neutron
+  when:
+    - "neutron_services['opflex-aim-aid']['group'] in group_names"
+  tags:
+    - opflex-config
+    - opflex-aim-config
+
 - name: Ensure aim config directory and log files exists
   file:
     path: "{{ item.path }}"
@@ -128,10 +155,10 @@
       mode: "0755"
     - path: /run/aid/events
       state: directory
-      mode: "0755"
+      mode: "02755"
     - path: /run/aim-aid
       state: directory
-      mode: "0755"
+      mode: "02755"
 #    - path: /var/log/neutron/aim-aid.log
 #      state: touch
 #      mode: "0640"
@@ -192,7 +219,7 @@
   become_user: "{{ neutron_system_user_name }}"
   notify: Restart neutron services
   when:
-    - "ansible_local['openstack_ansible']['neutron']['need_gbp_init'] | bool"
+    - "ansible_local['openstack_ansible']['neutron']['need_gbp_init'] | defaut(false) | bool"
     - "inventory_hostname == groups[neutron_services['neutron-server']['group']][0]"
     - "neutron_services['neutron-server']['group'] in group_names"
   tags:
@@ -216,7 +243,7 @@
   become_user: "{{ neutron_system_user_name }}"
   notify: Restart neutron services
   when:
-    - "ansible_local['openstack_ansible']['neutron']['need_aim_upgrade'] | bool"
+    - "ansible_local['openstack_ansible']['neutron']['need_aim_upgrade'] | defaut(false) | bool"
     - "inventory_hostname == groups[neutron_services['neutron-server']['group']][0]"
     - "neutron_services['opflex-aim-aid']['group'] in group_names"
   tags:
@@ -240,7 +267,7 @@
   become_user: "{{ neutron_system_user_name }}"
   notify: Restart neutron services
   when:
-    - "ansible_local['openstack_ansible']['neutron']['need_aim_upgrade'] | bool"
+    - "ansible_local['openstack_ansible']['neutron']['need_aim_upgrade'] | defaut(false) | bool"
     - "inventory_hostname == groups[neutron_services['neutron-server']['group']][0]"
     - "neutron_services['opflex-aim-aid']['group'] in group_names"
   tags:
@@ -253,7 +280,7 @@
   become_user: "{{ neutron_system_user_name }}"
   notify: Restart neutron services
   when:
-    - "ansible_local['openstack_ansible']['neutron']['need_aim_init'] | bool"
+    - "ansible_local['openstack_ansible']['neutron']['need_aim_init'] | defaut(false) | bool"
     - "inventory_hostname == groups[neutron_services['neutron-server']['group']][0]"
     - "neutron_services['opflex-aim-aid']['group'] in group_names"
   tags:
@@ -265,7 +292,7 @@
   become_user: "{{ neutron_system_user_name }}"
   notify: Restart neutron services
   when:
-    - "ansible_local['openstack_ansible']['neutron']['need_aim_init'] | bool"
+    - "ansible_local['openstack_ansible']['neutron']['need_aim_init'] | defaut(false) | bool"
     - "inventory_hostname == groups[neutron_services['neutron-server']['group']][0]"
     - "neutron_services['opflex-aim-aid']['group'] in group_names"
   tags:

--- a/tasks/opflex.yml
+++ b/tasks/opflex.yml
@@ -155,10 +155,10 @@
       mode: "0755"
     - path: /run/aid/events
       state: directory
-      mode: "02755"
+      mode: "2755"
     - path: /run/aim-aid
       state: directory
-      mode: "02755"
+      mode: "2755"
 #    - path: /var/log/neutron/aim-aid.log
 #      state: touch
 #      mode: "0640"


### PR DESCRIPTION
Mainly fixes some installation hangups. 

The tmpfiles.d config ensures that the /var/run directories needed by opflex services / aim-aid are created again after the server is rebooted. 