### PR TITLE
Ensure pyasyncore pip package is installed

### DIFF
--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -123,6 +123,7 @@ neutron_opflex_distro_ovs_agent_packages:
   - name: openvswitch-common
   - name: openvswitch-switch
   - name: supervisor
+  - name: pyasyncore
 
 opflex_apt_repo_url: "http://localhost/ubuntu"
 opflex_repo:


### PR DESCRIPTION
This dependency is no longer automatically installed in newer python versions and is needed by neutron-opflex-agent